### PR TITLE
Update to alpine:3.14 and cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM alpine:3.12
+FROM alpine:3.14
 
-RUN apk --no-cache --update add bash git \
-    && rm -rf /var/cache/apk/*
+RUN apk --no-cache --update add bash
 
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 


### PR DESCRIPTION
Git is not needed inside image, --no-cache takes care of removing cache files