### PR TITLE
Update workflow example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ jobs:
   tfsec:
     name: tfsec sarif report
     runs-on: ubuntu-latest
-
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - name: Clone repo
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: tfsec
         uses: aquasecurity/tfsec-sarif-action@v0.1.0


### PR DESCRIPTION
This patch makes the following changes to the example workflow in the `README.md`:

 - pin the `actions/checkout` action to `v2` instead of `master`
 - set `persist-credentials: false` as a good practice so that the `$GITHUB_TOKEN` is not made available to any action unless explicitly configured (checkout will sneakily write the token to disk where any step can pick it up)
 - Add a `permissions` section to limit the scope of the `$GITHUB_TOKEN` to just be able to read the repo contents and add security events.
 
Assuming many folks copy/paste the example workflow from the `README.md`, I think these are good security changes to encourage.