### PR TITLE
docs: update actions/checkout branch name to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
 
       - name: tfsec
         uses: aquasecurity/tfsec-sarif-action@v0.1.0


### PR DESCRIPTION
Their `master` branch has moved to `main`, but the example may as well point to `v3`

See also: https://github.com/aquasecurity/tfsec/pull/1701