### PR TITLE
Set default value for TFSEC_VERSION

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ if [ -n "${GITHUB_WORKSPACE}" ]; then
   cd "${GITHUB_WORKSPACE}" || exit
 fi
 
-TFSEC_VERSION=""
+TFSEC_VERSION="latest"
 if [ "$INPUT_TFSEC_VERSION" != "latest" ]; then
   TFSEC_VERSION="tags/${INPUT_TFSEC_VERSION}"
 fi


### PR DESCRIPTION
`TFSEC_VERSION` is currently set to an empty string if the input `tfsec_version` is set to `latest` or if it's omitted, causing the action to fail. 

Fixes #27 