### PR TITLE
remove trailing slash for default behavior.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,11 +8,12 @@ fi
 
 TFSEC_VERSION=""
 if [ "$INPUT_TFSEC_VERSION" != "latest" ]; then
-  TFSEC_VERSION="tags/${INPUT_TFSEC_VERSION}"
+  TFSEC_VERSION="/tags/${INPUT_TFSEC_VERSION}"
 fi
 
-wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec-linux-amd64
-wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec_checksums.txt" | head -n1)" > tfsec.checksums
+# Pull https://api.github.com/repos/aquasecurity/tfsec/releases for the full list of releases. NOTE no trailing slash
+wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec-linux-amd64
+wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec_checksums.txt" | head -n1)" > tfsec.checksums
 
 grep tfsec-linux-amd64 tfsec.checksums > tfsec-linux-amd64.checksum
 sha256sum -c tfsec-linux-amd64.checksum


### PR DESCRIPTION
The trailing slash is causing issues as `https://api.github.com/repos/aquasecurity/tfsec/releases` will return the
full list of releases where as `https://api.github.com/repos/aquasecurity/tfsec/releases/` will not.

when using the `INPUT_TFSEC_VERSION`, prepend a slash for the path to be fully formed.

Signed-off-by: Kenny Leung <kleung@chainguard.dev>