### PR TITLE
Add arm64 support, switch to `latest` alpine so Docker image is cached through Google's mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.15.2
+FROM alpine:latest
+ARG TARGETPLATFORM
 
 RUN apk --no-cache --update add bash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM alpine:latest
-ARG TARGETPLATFORM
 
 RUN apk --no-cache --update add bash
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,22 +7,31 @@ if [ -n "${GITHUB_WORKSPACE}" ]; then
   cd "${GITHUB_WORKSPACE}" || exit
 fi
 
+ARCH=$(uname -m)
+if [ "${ARCH}" == "x86_64" ]; then
+  ARCH="amd64"
+fi
+
+if [ "${ARCH}" == "aarch64" ] || [ "${ARCH}" == "arm64" ]; then
+  ARCH="arm64"
+fi
+
 # default to latest
 TFSEC_VERSION="latest"
 
 # if INPUT_TFSEC_VERSION set and not latests
-if [ -n "${INPUT_TFSEC_VERSION}" && "$INPUT_TFSEC_VERSION" != "latest" ]; then
+if [ -n "${INPUT_TFSEC_VERSION}" ] && [ "${INPUT_TFSEC_VERSION}" != "latest" ]; then
   TFSEC_VERSION="tags/${INPUT_TFSEC_VERSION}"
 fi
 
 # Pull https://api.github.com/repos/aquasecurity/tfsec/releases for the full list of releases. NOTE no trailing slash
-wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec-linux-amd64
+wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec-linux-${ARCH}" | head -n1)" > "tfsec-linux-${ARCH}"
 wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec_checksums.txt" | head -n1)" > tfsec.checksums
 
 # pipe out the checksum and validate
-grep tfsec-linux-amd64 tfsec.checksums > tfsec-linux-amd64.checksum
-sha256sum -c tfsec-linux-amd64.checksum
-install tfsec-linux-amd64 /usr/local/bin/tfsec
+grep "tfsec-linux-${ARCH}" tfsec.checksums > tfsec-linux-amd64.checksum
+sha256sum -c "tfsec-linux-${ARCH}.checksum"
+install "tfsec-linux-${ARCH}" /usr/local/bin/tfsec
 
 # if input vars file then add to arguments
 if [ -n "${INPUT_TFVARS_FILE}" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -xe
 
 # Check for a github workkspace, exit if not found

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases
 wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec_checksums.txt" | head -n1)" > tfsec.checksums
 
 # pipe out the checksum and validate
-grep "tfsec-linux-${ARCH}" tfsec.checksums > tfsec-linux-amd64.checksum
+grep "tfsec-linux-${ARCH}" tfsec.checksums > "tfsec-linux-${ARCH}.checksum"
 sha256sum -c "tfsec-linux-${ARCH}.checksum"
 install "tfsec-linux-${ARCH}" /usr/local/bin/tfsec
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "schedule:earlyMondays"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        ".*"
+      ],
+      "groupName": "non-major packages",
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Added arm64 support for the entrypoint (we use self-hosted arm64 runners)
- Switched image to `alpine:latest` because that gets cached with [Google's Docker Hub mirror](https://mirror.gcr.io/). This latter is important because the Docker image gets build before I could even log in to Docker Hub, and I get hit with the pull limit. However Google only ever caches the `latest` tag of public images.