### PR TITLE
add git and hg to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.15.2
 
-RUN apk --no-cache --update add bash
+RUN apk --no-cache --update add bash git mercurial
 
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 


### PR DESCRIPTION
When running the action against terraform containing modules sourced over `git`, the action would fail with the following message:

Example Terraform:
```
module "sigstore" {
  source = "git::https://github.com/sigstore/scaffolding.git//terraform/gcp/modules/sigstore?ref=130f8b87521ef67bf03486166385c36fff49ba4a"
  ...
```

Log message from tfsec-sarif-action:
```
terraform.parser.<root>.evaluator Failed to load module 'failed to download: error downloading 'https://github.com/sigstore/scaffolding.git?ref=130f8b87521ef67bf03486166385c36fff49ba4a': git must be available and on the PATH'. Maybe try 'terraform init'?
```

This commit adds the `git` and `hg` binaries to the underlying base image to ensure that the full module content is fetched and analyzed.

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>