### PR TITLE
Replace deprecated `set-output` usage with environment file `GITHUB_OUTPUT`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,4 +56,4 @@ tfsec --soft-fail --out=${INPUT_SARIF_FILE} --format=sarif ${TFSEC_ARGS_OPTION} 
 
 tfsec_return="${PIPESTATUS[0]}" exit_code=$?
 
-echo ::set-output name=tfsec-return-code::"${tfsec_return}"
+echo "tfsec-return-code=${tfsec_return}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Resolves https://github.com/aquasecurity/tfsec-sarif-action/issues/34