### PR TITLE
Fix conditional expression for setting `TFSEC_VERSION`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ fi
 TFSEC_VERSION="latest"
 
 # if INPUT_TFSEC_VERSION set and not latests
-if [ -n "${INPUT_TFSEC_VERSION}" && "$INPUT_TFSEC_VERSION" != "latest" ]; then
+if [[ -n "${INPUT_TFSEC_VERSION}" && "$INPUT_TFSEC_VERSION" != "latest" ]]; then
   TFSEC_VERSION="tags/${INPUT_TFSEC_VERSION}"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ fi
 # default to latest
 TFSEC_VERSION="latest"
 
-# if INPUT_TFSEC_VERSION set and not latests
+# if INPUT_TFSEC_VERSION set and not latest
 if [[ -n "${INPUT_TFSEC_VERSION}" && "$INPUT_TFSEC_VERSION" != "latest" ]]; then
   TFSEC_VERSION="tags/${INPUT_TFSEC_VERSION}"
 fi


### PR DESCRIPTION
The action currently doesn't apply the `tfsec_version` input parameter because of a syntax error in the script (introduced in commit https://github.com/aquasecurity/tfsec-sarif-action/commit/5d34a982aa8927c5dd8566d25ef248d526aac1f4). The following error message is displayed in workflows:
```sh
/entrypoint.sh: line 14: [: missing `]'
```

This PR switches to using double brackets for the conditional expression enabling the use of `&&`.