### PR TITLE
Forcing wget to use IPv4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --no-cache --update add bash wget
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 
 COPY entrypoint.sh /entrypoint.sh
-ADD --checksum=sha256:17c1bd99ebe13be77ac775651bc61f44b2b4409b4578485f1168eab8c3e97507 https://github.com/aquasecurity/tfsec/releases/download/v1.28.1/tfsec-linux-amd64 .
+ADD https://github.com/aquasecurity/tfsec/releases/download/v1.28.1/tfsec-linux-amd64 .
 RUN install tfsec-linux-amd64 /usr/local/bin/tfsec
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,7 @@ RUN apk --no-cache --update add bash wget
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 
 COPY entrypoint.sh /entrypoint.sh
+ADD --checksum=sha256:17c1bd99ebe13be77ac775651bc61f44b2b4409b4578485f1168eab8c3e97507 https://github.com/aquasecurity/tfsec/releases/download/v1.28.1/tfsec-linux-amd64 .
+RUN install tfsec-linux-amd64 /usr/local/bin/tfsec
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.16.2
 
-RUN apk --no-cache --update add bash wget
+RUN apk --no-cache --update add bash
 
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.15.2
+FROM alpine:3.16.2
 
-RUN apk --no-cache --update add bash
+RUN apk --no-cache --update add bash wget
 
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.16.2
 
-RUN apk --no-cache --update add bash
+RUN apk --no-cache --update add bash wget
 
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,8 +16,8 @@ if [ -n "${INPUT_TFSEC_VERSION}" && "$INPUT_TFSEC_VERSION" != "latest" ]; then
 fi
 
 # Pull https://api.github.com/repos/aquasecurity/tfsec/releases for the full list of releases. NOTE no trailing slash
-wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec-linux-amd64
-wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec_checksums.txt" | head -n1)" > tfsec.checksums
+wget --inet4-only -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec-linux-amd64
+wget --inet4-only -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec_checksums.txt" | head -n1)" > tfsec.checksums
 
 # pipe out the checksum and validate
 grep tfsec-linux-amd64 tfsec.checksums > tfsec-linux-amd64.checksum

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,8 +16,8 @@ if [ -n "${INPUT_TFSEC_VERSION}" && "$INPUT_TFSEC_VERSION" != "latest" ]; then
 fi
 
 # Pull https://api.github.com/repos/aquasecurity/tfsec/releases for the full list of releases. NOTE no trailing slash
-wget --inet4-only -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec-linux-amd64
-wget --inet4-only -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec_checksums.txt" | head -n1)" > tfsec.checksums
+wget --inet4-only -O - -q "$(wget --inet4-only -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec-linux-amd64
+wget --inet4-only -O - -q "$(wget --inet4-only -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec_checksums.txt" | head -n1)" > tfsec.checksums
 
 # pipe out the checksum and validate
 grep tfsec-linux-amd64 tfsec.checksums > tfsec-linux-amd64.checksum

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,14 +15,14 @@ if [ -n "${INPUT_TFSEC_VERSION}" && "$INPUT_TFSEC_VERSION" != "latest" ]; then
   TFSEC_VERSION="tags/${INPUT_TFSEC_VERSION}"
 fi
 
-# Pull https://api.github.com/repos/aquasecurity/tfsec/releases for the full list of releases. NOTE no trailing slash
-wget --inet4-only -O - -q "$(wget --inet4-only -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec-linux-amd64
-wget --inet4-only -O - -q "$(wget --inet4-only -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec_checksums.txt" | head -n1)" > tfsec.checksums
+# # Pull https://api.github.com/repos/aquasecurity/tfsec/releases for the full list of releases. NOTE no trailing slash
+# wget --inet4-only -O - -q "$(wget --inet4-only -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec-linux-amd64
+# wget --inet4-only -O - -q "$(wget --inet4-only -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec_checksums.txt" | head -n1)" > tfsec.checksums
 
-# pipe out the checksum and validate
-grep tfsec-linux-amd64 tfsec.checksums > tfsec-linux-amd64.checksum
-sha256sum -c tfsec-linux-amd64.checksum
-install tfsec-linux-amd64 /usr/local/bin/tfsec
+# # pipe out the checksum and validate
+# grep tfsec-linux-amd64 tfsec.checksums > tfsec-linux-amd64.checksum
+# sha256sum -c tfsec-linux-amd64.checksum
+# install tfsec-linux-amd64 /usr/local/bin/tfsec
 
 # if input vars file then add to arguments
 if [ -n "${INPUT_TFVARS_FILE}" ]; then


### PR DESCRIPTION
Ran into an issue where the `wget` calls were failing with the following error:
```
+ '[' -n /github/workspace ']'
+ cd /github/workspace
+ TFSEC_VERSION=latest
+ '[' -n latest
/entrypoint.sh: line [14](https://github.com/jasonjanderson/terraform-test/actions/runs/3323368838/jobs/5493621746#step:5:15): [: missing `]'
++ grep -m 1 -o -E 'https://.+?tfsec-linux-amd64'
++ wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/latest -O -
++ head -n1
wget: bad address 'api.github.com'
+ wget -O - -q ''
wget: bad address ''
```

Seems like the default busybox version of wget has issues when using a IPv6 network interface: https://stackoverflow.com/questions/66115118/wget-unable-to-resolve-host-address-github-com-inside-alpine-docker-image

Updated image to use the alpine version of wget and forcing IPv4 like what's suggested in the article.

Before change: https://github.com/jasonjanderson/terraform-test/actions/runs/3323368838/jobs/5493621746
After change: https://github.com/jasonjanderson/terraform-test/actions/runs/3324210862/jobs/5495510589