### PR TITLE
Update README to use latest sarif action

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
           sarif_file: tfsec.sarif          
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: tfsec.sarif         


### PR DESCRIPTION
[GitHub deprecated and have since removed v1 of the sarif action](https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/)

Minor update to specify version 2. The action version for tfsec-sarif-action update is part of #40